### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,66 @@
-## Core Devs Meetings
+# Core Devs Meetings
 
-### Purpose
-The core devs meeting is a technical meeting intended to bring together various Filecoin teams who play major roles in determining the direction of the protocol. Filecoin implementation and research teams provide updates to their projects, discuss the implementation of various [FIPs](https://github.com/filecoin-project/FIPs) to improve the protocol, and support each other as we build a decentralized, efficient, and robust foundation for humanity’s information.
+## Purpose
+The core devs meeting is a technical meeting intended to bring together various Filecoin teams who play major roles in determining the direction of the protocol. Filecoin implementation and research teams provide updates to their projects, discuss the implementation of various [FIPs](https://github.com/filecoin-project/FIPs), set priorities for network upgrades, and are convened for decisionmaking in the instance of a network -critical security breach or bug. 
 
-### Previous Meetings
+Core Devs provide a central pillar of technical expertise to the broader Filecoin community as we work to build a decentralized, efficient, and robust foundation for humanity’s most important information.
+
+## Recent Meetings
 
  №  | Date                             | Agenda         |Notes          | Recording            |
 --- | -------------------------------- | -------------- |-------------- | -------------------- |
-  1 | Friday, September 11, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/1) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200001.md) | [recording](https://youtu.be/BB6uiZ0h35g) |
-  2 | Friday, September 25, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/3) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200002.md) | [recording](https://youtu.be/2xk1PWYqhxU) |
-  3 | Thursday, October 8, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/5) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200003.md) | [recording](https://youtu.be/ExFBGD3sjHk) |
-  4 | Thursday, October 22, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/7) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200004.md) | [recording](https://youtu.be/58b8TY9LJaM) |
-  5 | Thursday, November 5, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/9) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200005.md) | [recording](https://youtu.be/jCJFhhR0gW8) |
-  6 | Thursday, November 19, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/13) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200006.md) | [recording](https://youtu.be/t9W4Yl4sgwY) |
-  7 | Thursday, December 3, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/15) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200007.md) | [recording](https://www.youtube.com/watch?v=4naFxk_mcLc) |
-  8 | Thursday, December 17, 2020       | [agenda](https://github.com/filecoin-project/tpm/issues/20) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200008.md) | [recording](https://www.youtube.com/watch?v=DqKlP33qi4c) |
-  9 | Thursday, January 14, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/22) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200009.md) | [recording](https://www.youtube.com/watch?v=Rrw_y-YLeYM) |
-  10 | Thursday, January 28, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/23) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200010.md) | [recording](https://www.youtube.com/watch?v=WpizQgmmuSw) |
-  11 | Thursday, February 11, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/24) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200011.md) | [recording](https://www.youtube.com/watch?v=0ac7NT6wiPE) |
-  12 | Thursday, February 25, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/25) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200012.md) | [recording](https://www.youtube.com/watch?v=lmaBuSRz6Rk) |
-  13 | Thursday, March 11, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/27) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200013.md) | [recording](https://www.youtube.com/watch?v=Ot9uObGa7rs) |
-  14 | Thursday, March 25, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/31) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200014.md) | [recording](https://www.youtube.com/watch?v=utHInpSmoxw) |
-  15 | Thursday, April 8, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/34) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200015.md) | [recording](https://www.youtube.com/watch?v=7P2XrnggUd4) |
-  16 | Thursday, April 22, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/36) | TODO | TODO |
-  17 | Thursday, May 6, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/37) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200017.md) | [recording](https://www.youtube.com/watch?v=Ipd4x0cAEHw) |
-  18 | Thursday, May 20, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/40) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200018.md) | [recording](https://www.youtube.com/watch?v=L2SMR4gjQ3I) |
-  19 | Thursday, June 3, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/41) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200019.md) | [recording](https://www.youtube.com/watch?v=BROBqe2SOxA) |
-  20 | Thursday, June 17, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/45) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200020.md) | [recording](https://www.youtube.com/watch?v=wHr5lbtD_Z8) |
-  21 | Thursday, July 1, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/49) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200021.md) | [recording](https://www.youtube.com/watch?v=N4vSBvSXTMc) |
-  22 | Thursday, July 15, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/52) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200022.md) | [recording](https://www.youtube.com/watch?v=DGrBmODsgWE) |
-  23 | Thursday, July 29, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/55) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200023.md) | [recording](https://www.youtube.com/watch?v=Ni2DrljIhic) |
-  24 | Thursday, August 12, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/58) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200024.md) | [recording](https://www.youtube.com/watch?v=PrALVljYYGY) |
-  25 | Thursday, August 26, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/59) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200025.md) | [recording](https://www.youtube.com/watch?v=LpvGVmTYBCg) |
-  26 | Thursday, September 9, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/65) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200026.md) | [recording](https://www.youtube.com/watch?v=QxYvfVCGPgE&t=2022s) |
-  27 | Thursday, September 23, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/67) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200027.md)| [recording](https://www.youtube.com/watch?v=ClebmO4OfWQ&t=4s) |
-  28 | Thursday, October 7, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/70) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200028.md) | [recording](https://youtu.be/ZKh754jAqHY) |
-  29 | Thursday, October 21, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/73) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200029.md) | [recording](https://youtu.be/1dp9OOBt2JU)|
-  30 | Thursday, November 4, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/75) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200030.md) | [recording](https://www.youtube.com/watch?v=-ODA7hSgRcw)|
-  31 | Thursday, November 18, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/76) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200031.md) | [recording](https://www.youtube.com/watch?v=nm6_s2GZuFs)|
-  32 | Thursday, December 2, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/77) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200032.md) | [recording](https://www.youtube.com/watch?v=nSMrYugNbF8)|
-  33 | Thursday, December 16, 2021       | [agenda](https://github.com/filecoin-project/tpm/issues/79) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200033.md) | [recording](https://www.youtube.com/watch?v=X4e5fhckbKw)
-  34 | Thursday, January 13, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/86) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200034.md) | [recording](https://youtu.be/a1wcjZm50Zo)
-  35 | Thursday, January 27, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/88) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200035.md) | [recording](https://youtu.be/2kVQ5qwegok)
-  36 | Thursday, February 10, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/89) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200036.md) | [recording](https://www.youtube.com/watch?v=i80GCrXgTrU)
-  37 | Thursday, February 24, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/92) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200037.md) | [recording](https://youtu.be/aK1wRIiDqJw)
-  38 | Thursday, March 10, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/93) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200038.md) | [meeting 1](https://www.youtube.com/watch?v=YDMQWcbuse0&t=6s) & [meeting 2](https://www.youtube.com/watch?v=nuq_gguQp1g) |
-  39 | Thursday, March 24, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/96) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200039.md) | [meeting 1](https://www.youtube.com/watch?v=ZxjrC4nxw4w&list=PL_0VrY55uV1-9t74K-eFQN7Bc7ROG06hT&index=30) & meeting 2 (N/A) |
-  40 | Thursday, April 7, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/97) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200040.md) | [meeting 1](https://www.youtube.com/watch?v=1SWp2fVxdvU) & [meeting 2](https://www.youtube.com/watch?v=ApfGFIbn_9Q) |
-  41 | Thursday, April 21, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/98) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200041.md) | [meeting 1](https://www.youtube.com/watch?v=RFcYvSJ9dXI) & [meeting 2](https://www.youtube.com/watch?v=4iKoXVpZ_70) |
-  42 | Thursday, May 5, 2022       | [agenda](https://github.com/filecoin-project/tpm/issues/99) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200042.md) | [meeting](https://www.youtube.com/watch?v=VngperRIaSw) 1 & meeting 2 (N/A)  |
-  43 | Thursday, May 29, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/101) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200043.md) | [meeting 1](https://www.youtube.com/watch?v=JlG-u8ZDzAs) & [meeting 2]() |
-  44 | Thursday, June 2, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/102) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200044.md) | [meeting 1](https://youtu.be/j0Tin-r9vIg) & [meeting 2](https://www.youtube.com/watch?v=GJMtPTBmZfE) |
-  45 | Thursday, June 16, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/103) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200045.md) | [meeting 1](https://www.youtube.com/watch?v=aQAho3bmUOw) & [meeting 2](https://www.youtube.com/watch?v=AB1aG1Mlc-Y) |
-  46 | Thursday, June 30, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/105) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200046.md) | [meeting 1](https://www.youtube.com/watch?v=dY09LhYyyLw) & [meeting 2](https://www.youtube.com/watch?v=lkplUXZFvq8) |
-  47 | Thursday, July 14, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/107) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200047.md) | [meeting 1](https://www.youtube.com/watch?v=zHe72xR3KUM) & meeting 2 (N/A) |
-  48 | Thursday, August 4, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/109) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200048.md) | [meeting](https://www.youtube.com/watch?v=ArL82GRcJ3U) |
-  49 | Thursday, September 1, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/110) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200049.md) | [meeting](https://www.youtube.com/watch?v=Zm1eNpGK6Zw) |
-  50 | Thursday, October 6, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/111) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200050.md)| [meeting](https://www.youtube.com/watch?v=pvrGxhelIkU) |
+49 | Thursday, September 1, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/110) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200049.md) | [meeting](https://www.youtube.com/watch?v=Zm1eNpGK6Zw) |
+50 | Thursday, October 6, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/111) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200050.md)| [meeting](https://www.youtube.com/watch?v=pvrGxhelIkU) |
 51 | Friday, November 11, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/120) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting0051.md)| [meeting](https://www.youtube.com/watch?v=NaaJ-pqzMxE) |
 52 | Thursday, December 1, 2022      | [agenda](https://github.com/filecoin-project/tpm/issues/122) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting0052.md)| [meeting](https://youtu.be/v_ljI98Xrl8) |
 53 | Thursday, January 5, 2023      | [agenda](https://github.com/filecoin-project/tpm/issues/124) | [notes](https://github.com/filecoin-project/tpm/blob/master/Core%20Dev%20Meetings/Meeting%200053.md)| [meeting](https://youtu.be/MRV6f7jwVE0) |
-### Who Can Attend
-Low-level protocol developers, implementation developers, and core Filecoin researchers are invited to attend the meetings. Generally every Filecoin implementation  is represented, along with key members of research/scaling teams. Sometimes, a non-core developer with particular expertise on a topic is invited on to discuss a specific agenda item. If you feel you would contribute to the meetings by your attendance please reach out to [kaitlin@fil.org](mailto:kaitlin@fil.org).
 
-### Meeting Scheduling 
-Historically, Core Devs meetings have happened biweekly on Thursdays at 16:00 UTC. 
+A full record of all meetings can be found [HERE](https://www.youtube.com/@FilecoinProject). 
 
-However, as the Filecoin ecosystem continues to grow, this single meeting time has proven challenging for network contributors in certain Asian/Oceanic timezones. Beginning March 22, with Core Devs #38, the meeting will move to two biweekly meetings, both held on Thursday.  The first will be at 16:00 UTC, and the second at 00:00 UTC the following day. 
+A full record of all meeting notes can be found [HERE](https://github.com/filecoin-project/core-devs/tree/master/Core%20Dev%20Meetings). 
 
-Core Devs are welcome to attend one or both of these meetings, with updates prepared in advance and shared across all teams.  Guest presenters are asked to attend both meetings, if possible. 
+## Who Can Attend
+As an open source project, anyone is able to contribute their work, skills, or other expertise to Filecoin.  Individuals do not need to be 'Core Devs' to develop the Filecoin tech stack, or make meaningful contributions to the Filecoin community. 
 
-### Agenda Items
-Agendas are posted to https://github.com/filecoin-project/tpm/issues. Anyone is welcome to add an item to the agenda as long as it follows these guidelines:
-- The topic is technical in nature.
-- The topic involves the Filecoin protocol at a low-level (vs higher level FRCs).
-- The topic should not be philosophical. The core developer meetings are not meant to decide philosophical contentious issues that should be decided by the community. There are exceptions to this, but generally these topics distract from more productive technical discussion.
+Typically, core devs are individuals who have 1) been involved in the project for a long time, are 2) deeply knowledge about the Filecoin protocol and related subsystems, and 3) are interested in committing their time and expertise to reviewing work and contributing technical guidance outside of their immediate work domain. Furthermore, individuals who serve as Core Devs are publicly known, expected to participate in monthly Core Devs meetings, and are included in closed communication channels in order to discuss technical issues related to the security and development of the Filecoin protocol. 
 
-### Who Manages the Meetings
-As of August 2021, [@kaitlin-beegle](https://github.com/kaitlin-beegle) facilitates meetings, handles recordings, and publishes notes from the meetings.
+### Becoming a Core Dev
+* Anyone who wishes to become a Core Dev can send their request to the repo admin, Kaitlin Beegle (kaitlin@fil.org, or @kaitlin_FF on Slack) 
+* Your request will be flagged for existing Core Devs, who are asked to consider your inclusion according to open source principles of [thoughtful meritocracy](https://postmeritocracy.org/). 
+* If no one opposes your inclusion, you will be added to the meeting invite and all private groups.  You will be listed publicly as a Core Dev. 
+* If anyone raises meaningful opposition to your inclusion, a simple majority vote to accept or reject your request will be levied at the next Core Devs meeting.
+
+### Core Dev Observers
+Occasionally, Filecoin community members may want or need to join a Core Devs meeting.  Common reasons for this include: 
+   * They are authoring a FIP and have been asked to present their proposal. 
+   * They have expertise in a topic of discussion, and have been asked to contribute their knowledge. 
+   * Their work is relevant to a series of Core Dev discussions (e.g., network upgrades) but they do not want to contribute as full Core Devs. 
+
+As a reminder, being a Core Dev means opting into a position of community leadership, lending your time to help move forward work and technical discussions for the entire Filecoin community.  Individuals can be signficant contributors to Filecoin and not serve as Core Devs. Please keep these expectations in mind when you request to observe or become a part of the group. 
+
+If you'd like to be an observer, please send your request to Kaitlin via email (kaitlin@fil.org) and explain exactly how many meetings you expect to be able to attend. 
+
+### Addendum: Removing a Core Dev
+Occassionally, the repo admins will review Core Dev attendance records and follow up with Core Devs who have been less engaged in the group.  These individuals will be reminded of group expectations and/or given the opportunity to step down as Core Devs. 
+
+Please note that Filecoin is a decentralized, global community.  As such, there are not currently any requirements for attendance or participation for Core Devs.  However, it is important that Core Devs be reachable, reliable, and engaged.  Anyone who wishes to maintain their status as a Core Dev is expected to be so. 
+
+Though unlikely, anyone can propose the removal of someone as a Core Dev.  If a significant reason is raised for removal, a simple majority vote among current Core Devs will be taken at the next Core Devs meeting. 
+
+## Meeting Scheduling 
+The schedule for Core Dev meetings periodically changes, depending on needs. 
+
+Currently, meetings occur monthly for one hour.  Exact timing alternates every other month: 
+* 16:00 UTC on the first Thursday of the month (odd-numbered months) 
+* 00:00 UTC on the first Friday of the month (even-numbered months) 
+
+## Agenda Items
+Agendas are posted to https://github.com/filecoin-project/tpm/issues. Anyone is welcome to add an item to the agenda.  Items should generally be technical in nature, and relate to FIPs, FRCs or other network standards, network upgrades, technical network operations, or security issues. 
+
+Please note that agenda items are accepted at the sole discretion of repo admins. 
+
+## Who Manages the Meetings
+As of August 2021, [@kaitlin-beegle](https://github.com/kaitlin-beegle) is the primary repo admin.  
+
 The meetings are independent of any organization. However, the Filecoin Foundation pays for the videoconference software used in the meetings. 
-
-See the IPFS [Host a Call](https://github.com/ipfs/team-mgmt/blob/master/HOST_A_CALL.md) instructions for guides on how to configure livestreaming.
 


### PR DESCRIPTION
Changed PREVIOUS MEETINGS to RECENT MEETINGS, and reduced table to only reflect the 5 most recent meetings.  This improves readability of the README text, and assists with wayfinding to the most relevant materials.  Included links to the meeting notes file, as well as additional  link to the Filecoin YouTube channel. 

Updated the WHO CAN ATTEND section to include information about adding core devs, adding observers, and removing a core dev.  This does not reflect any real process change, but rather makes explicit a previously implicit workflow.  Also included a reference to Coraline Ada Ehmke's Post-Meritocracy manifesto as a definition of the merit principles upon which a requested Core Dev ought to be considered. 

Updates MEETING SCHEDULING to reflect the current schedule. 

Updates AGENDA ITEMS to be more current with what is accepted as a meeting item. 

Updates WHO MANAGES THE MEETING to be current. 

Removed configuration instructions for livestreaming, since this is a closed meeting.