### PR TITLE
Remove dupes / adjust names

### DIFF
--- a/Core Dev attendance record
+++ b/Core Dev attendance record
@@ -22,15 +22,14 @@ Core Dev Group List
 | 13  | Aayush Rajasekaran | Lotus               |     |     |     |     |     |     |     |     |     |
 | 14  | zenground0         | Lotus               |     |     |     |     |     |     |     |     |     |
 | 15  | Lukasz             | Lotus               |     |     |     |     |     |     |     |     |     |
-| 16  | Wdaviau            | Lotus               |     |     |     |     |     |     |     |     |     |
-| 17  |Orjan Roren.        | Lotus               |     |     |     |     |     |     |     |     |     |
+| 17  | Ørjan Røren        | Lotus               |     |     |     |     |     |     |     |     |     |
 | 18  | Alex North         | CryptoNet Lab       |     |     |     |     |     |     |     |     |     |
 | 19  | Irene Giacomelli   | CryptoNet Lab       |     |     |     |     |     |     |     |     |     |
 | 20  | Kubuxu             | CryptoNet Lab       |     |     |     |     |     |     |     |     |     |
 | 21  | Nicola             | CryptoNet Lab       |     |     |     |     |     |     |     |     |     |
-| 22  | Luca.              | CryptoNet Lab       |     |     |     |     |     |     |     |     |     |
+| 22  | Luca               | CryptoNet Lab       |     |     |     |     |     |     |     |     |     |
 | 23  | Stebalien          | FVM                 |     |     |     |     |     |     |     |     |     |
-| 24  | raulk.             | FVM                 |     |     |     |     |     |     |     |
+| 24  | raulk              | FVM                 |     |     |     |     |     |     |     |
 | 25  | Dragan             | FVM                 |     |     |     |     |     |     |     |     |     |
 | 26  | Dimitris Vyzovitis | FVM                 |     |     |     |     |     |     |     |     |     |
 | 27  | Honghao            | Bedrock             |     |     |     |     |     |     |     |     |     |
@@ -38,16 +37,14 @@ Core Dev Group List
 | 29  | Juan Benet         | Protocol Labs       |     |     |     |     |     |     |     |     |     |
 | 30  | Molly Mackinlay    | Protocol Labs       |     |     |     |     |     |     |     |     |     |
 | 31  | Will Scott         | Protocol Labs       |     |     |     |     |     |     |     |     |     |
-| 32  | Lukasz             | Lotus               |     |     |     |     |     |     |     |     |     |
-| 33  | Whyrusleeping      | Outercore           |     |     |     |     |     |     |     |     |     |
 | 34  | ZX                 | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
 | 35  | Vik                | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
-| 36  | AX.                | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
+| 36  | AX                 | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
 | 37  | Juan Pablo         | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
-| 38  | Tom.               | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
+| 38  | Tom                | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
 | 39  | Shyam Sridhar      | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
 | 40  | Kiran Karra        | CryptoEconLab       |     |     |     |     |     |     |     |     |     |
 | 41  | Scott Conner       | FilDev              |     |     |     |     |     |     |     |     |     |
-| 42  | Adlrocha           | Bedrock             |     |     |     |     |     |     |     |     |     |
+| 42  | Adlrocha           | ConsensusLab        |     |     |     |     |     |     |     |     |     |
 | 43  | Why                | Bluesky             |     |     |     |     |     |     |     |     |     |
 | 44  | Deep Kapur         | Filecoin+           |     |     |     |     |     |     |     |     |     |


### PR DESCRIPTION
There were *several* duplicates. Also a few names/orgs were misspelled/misattributed.

I have **not** adjusted the S/N column: it would make the diff unreadable. Needs to happen in another commit