### PR TITLE
Network upgrade changelog for NV22

### DIFF
--- a/Network Upgrades/v22.md
+++ b/Network Upgrades/v22.md
@@ -1,0 +1,12 @@
+## FIPs included
+
+
+
+## Actors version
+
+
+
+
+## Protocol Improvements and Bugfixes
+
+- Multisig actor: Return transaction error data back to the user (https://github.com/filecoin-project/builtin-actors/pull/1422)


### PR DESCRIPTION
Bootstrapping the doc with https://github.com/filecoin-project/builtin-actors/pull/1422