### PR TITLE
Remove FIP0070 from nv21 scope

### DIFF
--- a/Network Upgrades/v21.md
+++ b/Network Upgrades/v21.md
@@ -4,7 +4,6 @@ This network upgrade introduces the following FIPs:
 
 - [FIP0052: Increase Max Sector Commitment to 3.5 years](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0052.md)
 - [FIP0059: Synthetic PoRep](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0059.md)
-- [FIP0070: Allow SPs to move partitions between deadlines](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0070.md)
 - [FIP0071: Deterministic State Access (IPLD Reachability)](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0071.md)
 - [FIP0072: Improved event syscall API](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0072.md) 
 - [FIP0073: Remove beneficiary from the self_destruct syscall](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0073.md)
@@ -29,7 +28,6 @@ available on release branch: [release/v12](https://github.com/filecoin-project/b
 - Storage miner actor: Replace the per-sector "simple QA power" value with a bitfield of flags (https://github.com/filecoin-project/builtin-actors/pull/1395)
 - Storage miner actor: Added proof types for Synthetic PoRep (https://github.com/filecoin-project/builtin-actors/pull/1409)
 - Storage miner actor: Removed support for v1 proof types (https://github.com/filecoin-project/builtin-actors/pull/1391)
-- Storage miner actor: Added MovePartitions method (https://github.com/filecoin-project/builtin-actors/pull/1326)
 - Updated FVM to v4 (https://github.com/filecoin-project/builtin-actors/commit/3c8244fad9844dd9cfde84e071728cbb10380371)
 - Changes to randomness drawing to accomodate FVM changes (https://github.com/filecoin-project/builtin-actors/pull/1378)
 - Remove beneficiary address from self-destruct (https://github.com/filecoin-project/builtin-actors/pull/1362)


### PR DESCRIPTION
This PRs mergeability depends on the resolution of the [nv21 decision matrix for the FIP0070 bug](https://filecoin.notion.site/nv21-decision-matrix-for-FIP0070-bug-a39174216ee1479eab9a55b2f23da520).

Specifically, it can only be merged if `Option 2: Descope FIP-0070 from nv21`  is chosen as the preferred course of action.