### PR TITLE
chore: Update Core Devs List

### DIFF
--- a/Core Devs List
+++ b/Core Devs List
@@ -39,3 +39,5 @@
 | 37  | Deep Kapur          | Filecoin+                        |
 | 38  | Andy Jackson        | Lotus Miner Lead                 |
 | 39  | Masih               | FilOz                            |
+| 40  | Hailong Mu          | Forest                           |
+| 41  | Shashank            | Forest                           |


### PR DESCRIPTION
@hanabi1224 and @sudo-shashank are already in the core-devs channel; this is just an update to the list.