### PR TITLE
Core Devs 82 meeting notes updates

### DIFF
--- a/Core Dev Meetings/Meeting 0082.md
+++ b/Core Dev Meetings/Meeting 0082.md
@@ -1,5 +1,6 @@
 # Filecoin Core Devs Monthly Meeting Notes
 Recording: https://danny.spesh.com/video/coredevs-2025-08-07/GMT20250807-150442_Recording_1790x920.mp4
+
 **August 7, 2025**
 
 ## Welcome Michael Madoff - New Head of Governance

--- a/Core Dev Meetings/Meeting 0082.md
+++ b/Core Dev Meetings/Meeting 0082.md
@@ -1,4 +1,5 @@
 # Filecoin Core Devs Monthly Meeting Notes
+Recording: https://danny.spesh.com/video/coredevs-2025-08-07/GMT20250807-150442_Recording_1790x920.mp4
 **August 7, 2025**
 
 ## Welcome Michael Madoff - New Head of Governance
@@ -20,20 +21,31 @@ A few were rejected based on author feedback. Everything is documented on GitHub
 
 ## NV27 Network Upgrade Planning
 
-Targeting **code freeze by end of August**. We decided to ship bite-sized upgrades rather than wait on Sealer ID.
+**Context:**  
+This table summarizes the revised **Network Upgrade (NV27) FIPs queue** discussed during **Core Devs Meeting 82**.  
+It reflects the latest status, timeline considerations, and prioritization of proposals based on Core Devs 82 discussions.  
 
-**Included in NV27**
-- `FIP-0105` — BLS pre-compiles *(note: ~2 MB size increase concern)*  
-- Three removal FIPs — `FIP-0103`, `FIP-0106`, `FIP-0101` *(cleanup of old methods)*  
-- `FIP-0077` — miner creation deposit set to **5 FIL** to prevent spam  
-- `FIP-0108` — F3 snapshots *(Forest team reports readiness)*
+**Tentative Timeline:**  
+The NV27 upgrade planning starts with a **target code freeze date of August 31, 2025**.  
 
-**Deferred**
-- **Sealer ID FIP** — still in draft; impacts Curio’s snark market plans  
-- `FIP-0107` — implicit messages *(implementation bandwidth)*
+---
 
-**Potential add**
-- `FIP-0109` — smart contract notifications *(~1 day of work; pending editor review)*
+| FIP/FRC | Link | Status & Progress | Timeline | Summary | Notes |
+|---------|------|-------------------|----------|---------|-------|
+| 🟢 **FIP-0105**: Add BLS12-381 precompiles to FEVM | [FIP-0105](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0105.md) | PR open; performance concern on 2MB WASM increase resolved [here](https://github.com/filecoin-project/builtin-actors/pull/1669) | No concerns for NV27 | Adds ~2MB to EVM actor compiled WASM; improves cryptographic capabilities | [Slack discussion](https://filecoinproject.slack.com/archives/C015KQQLQQ1/p1755128066766349) |
+| 🟢 **FIP-0103**: Remove `ExtendSectorExpiration` method | [FIP-0103](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0103.md) | PR opened, reviewed, merged | No concerns for NV27 | Removes deprecated method, replaced by `ExtendSectorExpiration2` already in use | Straightforward removal |
+| 🟢 **FIP-0106**: Remove `ProveReplicaUpdates` method | [FIP-0106](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0106.md) | PR opened, reviewed, merged | No concerns for NV27 | Second of three removal FIPs in NV27; straightforward | Already accepted |
+| 🟢 **FIP-0077**: Add deposit requirement for new miner creation | [FIP-0077](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0077.md) | All feedback resolved; ready to move from last call to accepted | No concerns; minor changes possible by month-end | Adds 5 FIL deposit for creating new miners; spam prevention | Deposit reduced from original proposal |
+| 🟢 **FIP-0101**: Remove `ProveCommitAggregate` method | [FIP-0101](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0101.md) | Third and final removal FIP in NV27; already accepted | No concerns for NV27 | Removes deprecated parameters | Straightforward removal |
+| 🟢 **FRC-0108**: F3-compatible snapshots | [FRC-0108](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0108.md) | Ready for NV27; Forest team ready by end of August; testnet phase planned | No concerns | Standardizes format for F3 data loading; backward compatible; not a protocol change but requires network upgrade | Ensures all nodes support new snapshot format |
+| 🟡 **FIP-0109**: Smart contract notifications for Direct Data Onboarding (DDO) | [PR #1180](https://github.com/filecoin-project/FIPs/pull/1180) | Potential for NV27 if reviewed in time; flagged to FIP editors | Low risk; minimal integration | Enables DDO-related smart contract notifications; unlocks marketplaces, DAOs, data apps | Waiting for 2 FIP editor reviews |
+| 🔴 **FIP-0107**: Implicit messages in block receipts | [FIP-0107](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0107.md) | Deferred to next upgrade | Misses August deadline | Would allow implicit messages in receipts; deferred due to lack of bandwidth in Lotus & Forest | Update to be posted in GitHub discussions |
+| 🔴 **Sealer ID** | [PR #993](https://github.com/filecoin-project/FIPs/pull/993) | Deferred; implementation specs still WIP | High-risk; deferred | Assigns unique ID to sealers; significant miner-actor change | Needs extensive testing; timeline too short |
+
+**Legend:**  
+- 🟢 Ready for NV27 (no timeline concerns)  
+- 🟡 Needs review / at risk but possible for NV27  
+- 🔴 Deferred to next upgrade  
 
 ## FIP100 Monitoring Committee Update
 


### PR DESCRIPTION
Updating Core Devs meeting notes with 3 changes:

1. Adding a new table showing NV'27 code-freeze planning and statuses of FIPs
2. Changing the alignment of the date
3. Adding a recording link of Core Devs 82